### PR TITLE
Revamp error handling

### DIFF
--- a/gitarena-macros/src/config.rs
+++ b/gitarena-macros/src/config.rs
@@ -98,7 +98,7 @@ impl Parse for Setting {
         input.parse::<Token![=>]>()?;
         let ty: Type = input.parse()?;
         let key_str = key.value();
-        let ident = Ident::new(key_str.replace(".", "_").as_str(), input.span());
+        let ident = Ident::new(key_str.replace('.', "_").as_str(), input.span());
 
         Ok(Setting {
             identifier: ident,

--- a/gitarena-macros/src/route.rs
+++ b/gitarena-macros/src/route.rs
@@ -152,7 +152,7 @@ impl ToTokens for ErrorDisplayType {
                 let unboxed = &**inner.clone();
 
                 let ts = unboxed.to_token_stream();
-                quote! { Htmx(crate::error::ErrorDisplayType::#ts) }
+                quote! { Htmx(Box::new(crate::error::ErrorDisplayType::#ts)) }
             },
             ErrorDisplayType::Json => quote! { Json },
             ErrorDisplayType::Git => quote! { Git },

--- a/gitarena-macros/src/route.rs
+++ b/gitarena-macros/src/route.rs
@@ -122,8 +122,10 @@ pub(crate) fn route(args: TokenStream, input: TokenStream) -> TokenStream {
             }
 
             Ok(#generated_ident_ts(#(#idents_vec),*).await.map_err(|err| {
+                use std::sync::Arc;
+
                 crate::error::GitArenaError {
-                    source: err,
+                    source: Arc::new(err),
                     display_type: crate::error::ErrorDisplayType::#error_type
                 }
             }))

--- a/gitarena-macros/src/route.rs
+++ b/gitarena-macros/src/route.rs
@@ -1,47 +1,65 @@
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use proc_macro::TokenStream;
-use proc_macro_error::abort;
+use proc_macro_error::{abort, abort_call_site, abort_if_dirty, emit_error};
 use quote::{quote, ToTokens};
-use syn::{AttributeArgs, Error, FnArg, ItemFn, Lit, LitStr, NestedMeta, parse_macro_input, Pat};
+use syn::spanned::Spanned;
+use syn::{AttributeArgs, FnArg, ItemFn, Lit, LitStr, Meta, NestedMeta, parse_macro_input, Pat};
 
 pub(crate) fn route(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut args = parse_macro_input!(args as AttributeArgs);
     let mut input = parse_macro_input!(input as ItemFn);
 
-    // Transform routes which are only a "/" to an empty string. This allows scoped routes to have index
-    // pages without having to declare their route with a literal empty string (which is quite confusing).
-    // This cannot be done inline because of https://github.com/rust-lang/rust/issues/59159,
-    // so we return a tuple which allows us to mutually borrow later if needed.
-    let (sanitize_slash, span) = if let Some(first_arg) = args.first() {
-        match first_arg {
-            NestedMeta::Lit(literal) => match literal {
-                Lit::Str(str) => {
-                    let value = str.value();
+    let mut error_type = ErrorDisplayType::Unset;
+    let mut error_type_index = 0;
+    let mut sanitized_first_arg = None;
 
-                    if value.is_empty() {
-                        abort! {
-                            str.span(),
-                            "route cannot be empty";
-                            help = "if you want to match on index, use \"/\"";
-                        }
-                    } else if value == "/" {
-                        (true, Some(str.span()))
-                    } else {
-                        (false, None)
+    for (index, meta) in args.iter().enumerate() {
+        match meta {
+            NestedMeta::Meta(meta) => if let Meta::NameValue(name_value) = meta {
+                if let Some(segment) = name_value.path.segments.first() {
+                    let lowered = segment.ident.to_string().to_lowercase();
+
+                    match lowered.as_str() {
+                        "err" => if let Some(parsed_error_type) = match_error_type(&name_value.lit) {
+                            error_type = parsed_error_type;
+                            error_type_index = index;
+                        },
+                        _ => { /* ignored */ }
+                    }
+                } else {
+                    emit_error! {
+                        meta.span(),
+                        "meta name cannot be empty"
                     }
                 }
-                _ => (false, None)
             }
-            NestedMeta::Meta(_) => (false, None)
+            NestedMeta::Lit(literal) if index == 0 => {
+                if let Some(meta) = sanitize_first_argument(literal) {
+                    sanitized_first_arg = Some(meta);
+                }
+            }
+            _ => { /* ignored - actix web will error if the attribute is invalid */ }
         }
-    } else {
-        (false, None)
-    };
+    }
 
-    if sanitize_slash {
-        args.insert(0, NestedMeta::Lit(Lit::Str(LitStr::new("", span.unwrap()))));
+    if matches!(error_type, ErrorDisplayType::Unset) {
+        abort_call_site! {
+            "function does not have \"err\" attribute";
+            help = "consider adding `err = \"html|htmx+(fallback)|json|git|text|plain\"`"
+        }
+    }
+
+    // actix-web doesn't know how to handle "err" so we remove it
+    args.remove(error_type_index);
+
+    // This cannot be done inline (with &mut) because of https://github.com/rust-lang/rust/issues/59159
+    if let Some(meta) = sanitized_first_arg {
+        args.insert(0, meta);
         args.remove(1);
     }
+
+    // Abort right now if the previous argument parsing emitted errors
+    abort_if_dirty();
 
     let attrs = &mut input.attrs;
     let vis = &input.vis;
@@ -49,9 +67,10 @@ pub(crate) fn route(args: TokenStream, input: TokenStream) -> TokenStream {
     let body = &input.block;
 
     if sig.asyncness.is_none() {
-        return Error::new_spanned(sig.fn_token, "function needs to be async")
-            .to_compile_error()
-            .into();
+        abort! {
+            sig.fn_token.span,
+            "function needs to be async"
+        }
     }
 
     // Create name for our generated function
@@ -105,4 +124,76 @@ pub(crate) fn route(args: TokenStream, input: TokenStream) -> TokenStream {
             Ok(#generated_ident_ts(#(#idents_vec),*).await.map_err(|e| -> crate::error::GitArenaError { e.into() }))
         }
     })
+}
+
+enum ErrorDisplayType {
+    Html,
+    Htmx(Box<ErrorDisplayType>),
+    Json,
+    Git,
+    Plain,
+
+    #[doc(hidden)]
+    Unset
+}
+
+fn match_error_type(input: &Lit) -> Option<ErrorDisplayType> {
+    if let Lit::Str(str) = input {
+        let value = str.value().to_lowercase();
+
+        return match value.as_str() {
+            "html" => Some(ErrorDisplayType::Html),
+            "json" => Some(ErrorDisplayType::Json),
+            "git" => Some(ErrorDisplayType::Git),
+            "text" | "plain" => Some(ErrorDisplayType::Plain),
+            "htmx!" => Some(ErrorDisplayType::Htmx(Box::new(ErrorDisplayType::Unset))),
+            "htmx+html" => Some(ErrorDisplayType::Htmx(Box::new(ErrorDisplayType::Html))),
+            "htmx+json" => Some(ErrorDisplayType::Htmx(Box::new(ErrorDisplayType::Json))),
+            "htmx+git" => Some(ErrorDisplayType::Htmx(Box::new(ErrorDisplayType::Git))),
+            "htmx+text" | "htmx+plain" => Some(ErrorDisplayType::Htmx(Box::new(ErrorDisplayType::Plain))),
+            "htmx" => {
+                emit_error! {
+                    input.span(),
+                    "htmx error handler requires fallback";
+                    help = "if this can never happen, define err as \"htmx!\" (dangerous!)"
+                }
+
+                None
+            }
+            _ => {
+                emit_error! {
+                    input.span(),
+                    "unknown error type";
+                    help = "accepted types are: \"html\", \"htmx+(fallback)\", \"json\", \"git\", \"text\" or \"plain\""
+                }
+
+                None
+            }
+        };
+    }
+
+    None
+}
+
+/// Transforms routes which are only a "/" to an empty string. This allows scoped routes to have index
+/// pages without having to declare their route with a literal empty string (which is quite confusing).
+fn sanitize_first_argument(literal: &Lit) -> Option<NestedMeta> {
+    match literal {
+        Lit::Str(str) => {
+            let value = str.value();
+
+            if value.is_empty() {
+                emit_error! {
+                    str.span(),
+                    "route cannot be empty";
+                    help = "if you want to match on index, use \"/\""
+                }
+            } else if value == "/" {
+                return Some(NestedMeta::Lit(Lit::Str(LitStr::new("", str.span()))));
+            }
+        }
+        _ => { /* ignored */ },
+    }
+
+    None
 }

--- a/gitarena-macros/src/route.rs
+++ b/gitarena-macros/src/route.rs
@@ -150,7 +150,7 @@ impl ToTokens for ErrorDisplayType {
                 let unboxed = &**inner.clone();
 
                 let ts = unboxed.to_token_stream();
-                quote! { Htmx(#ts) }
+                quote! { Htmx(crate::error::ErrorDisplayType::#ts) }
             },
             ErrorDisplayType::Json => quote! { Json },
             ErrorDisplayType::Git => quote! { Git },

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,12 @@
-use crate::error::GAErrors::TypeConstraintViolated;
-use crate::error::GAErrors;
+use crate::error::{ErrorHolder, HoldsError};
 
-use core::result::Result as CoreResult;
 use std::convert::{TryFrom, TryInto};
-use std::error::Error as StdError;
+use std::fmt::Debug;
 use std::future::Future;
+use std::result::Result as StdResult;
 use std::str::FromStr;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use derive_more::Display;
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -19,14 +18,14 @@ use tracing_unwrap::OptionExt;
 /// Gets the value of a setting from the database.
 ///
 /// If unset, returns None.
-/// If the setting does not match provided type, returns GA Err.
+/// If the setting does not match provided type, returns Anyhow Err.
 /// If the setting does not exist, returns SQL Err.
 ///
 /// The later case should never happen if the programmer added their setting to schema.sql
 pub(crate) async fn get_optional_setting<'e, T, E>(key: &'static str, executor: E) -> Result<Option<T>>
     where T: TryFrom<Setting> + Send,
           E: Executor<'e, Database = Postgres>,
-          <T as TryFrom<Setting>>::Error: StdError + Send + Sync + 'static
+          <T as TryFrom<Setting>>::Error: HoldsError + Send + Sync + 'static
 {
     let setting = sqlx::query_as::<_, Setting>("select * from settings where key = $1 limit 1")
         .bind(key)
@@ -35,7 +34,7 @@ pub(crate) async fn get_optional_setting<'e, T, E>(key: &'static str, executor: 
         .with_context(|| format!("Unable to read setting {} from database", key))?;
 
     if setting.is_set() {
-        let result: T = setting.try_into()?;
+        let result: T = setting.try_into().map_err(|err: T::Error| err.into_inner())?;
         Ok(Some(result))
     } else {
         Ok(None)
@@ -45,14 +44,14 @@ pub(crate) async fn get_optional_setting<'e, T, E>(key: &'static str, executor: 
 /// Gets the value of a setting from the database.
 ///
 /// If unset, returns GA Err.
-/// If the setting does not match provided type, returns GA Err.
+/// If the setting does not match provided type, returns Anyhow Err.
 /// If the setting does not exist, returns SQL Err.
 ///
 /// The later case should never happen if the programmer added their setting to schema.sql
 pub(crate) async fn get_setting<'e, T, E>(key: &'static str, executor: E) -> Result<T>
     where T: TryFrom<Setting> + Send,
           E: Executor<'e, Database = Postgres>,
-          <T as TryFrom<Setting>>::Error: StdError + Send + Sync + 'static
+          <T as TryFrom<Setting>>::Error: HoldsError + Send + Sync + 'static
 {
     let setting = sqlx::query_as::<_, Setting>("select * from settings where key = $1 limit 1")
         .bind(key)
@@ -60,7 +59,7 @@ pub(crate) async fn get_setting<'e, T, E>(key: &'static str, executor: E) -> Res
         .await
         .with_context(|| format!("Unable to read setting {} from database", key))?;
 
-    let result: T = setting.try_into()?;
+    let result: T = setting.try_into().map_err(|err: T::Error| err.into_inner())?;
     Ok(result)
 }
 
@@ -124,7 +123,8 @@ pub(crate) async fn create_tables(db_pool: &Pool<Postgres>) -> Result<()> {
     Ok(())
 }
 
-#[derive(FromRow, Debug, Deserialize, Serialize)]
+#[derive(FromRow, Debug, Deserialize, Serialize, Display)]
+#[display(fmt = "{}", key)]
 pub(crate) struct Setting {
     pub(crate) key: String,
     pub(crate) value: Option<String>,
@@ -155,48 +155,48 @@ impl Setting {
 macro_rules! generate_try_from {
     ($type_constraint:ident, $type_:ty) => {
         impl TryFrom<Setting> for $type_ {
-            type Error = GAErrors;
+            type Error = ErrorHolder;
 
-            fn try_from(setting: Setting) -> CoreResult<$type_, Self::Error> {
-                match setting.type_constraint {
+            fn try_from(setting: Setting) -> StdResult<$type_, Self::Error> {
+                (|| match setting.type_constraint {
                     TypeConstraint::$type_constraint => {
-                        let str = setting.value.ok_or_else(|| TypeConstraintViolated("None"))?;
-                        <$type_>::from_str(&str).map_err(|_| TypeConstraintViolated("value"))
+                        let str = setting.value.ok_or_else(|| anyhow!("Value for {} setting `{}` is not set", stringify!($type_constraint), setting))?;
+                        <$type_>::from_str(&str).map_err(|err| anyhow!("Expected valid value for {} on setting `{}` but instead received `{:?}`: {}", stringify!($type_constraint), setting, setting.value, err))
                     },
-                    _ => Err(TypeConstraintViolated(concat!("method: try_from<", stringify!($type_), ">")))
-                }
+                    _ => bail!("Tried to cast setting `{}` into {} despite it being {}", setting, stringify!($type_constraint), setting.type_constraint)
+                })().map_err(|err| ErrorHolder(err))
             }
         }
     }
 }
 
 impl TryFrom<Setting> for bool {
-    type Error = GAErrors;
+    type Error = ErrorHolder;
 
-    fn try_from(setting: Setting) -> CoreResult<bool, Self::Error> {
-        match setting.type_constraint {
+    fn try_from(setting: Setting) -> StdResult<bool, Self::Error> {
+        (|| match setting.type_constraint {
             TypeConstraint::Boolean => {
-                let str = setting.value.ok_or(TypeConstraintViolated("None"))?;
+                let str = setting.value.ok_or_else(|| anyhow!("Value for Boolean setting `{}` is not set", setting))?;
 
                 match str.to_lowercase().as_str() {
                     "1" | "true" => Ok(true),
                     "0" | "false" => Ok(false),
-                    _ => Err(TypeConstraintViolated("value"))
+                    _ => bail!("Expected valid value for boolean on setting `{}` but instead received `{}`", setting, str)
                 }
             }
-            _ => Err(TypeConstraintViolated("method: try_from<bool>"))
-        }
+            _ => bail!("Tried to cast setting `{}` into boolean despite it being {}", setting, setting.type_constraint)
+        })().map_err(|err| ErrorHolder(err))
     }
 }
 
 impl TryFrom<Setting> for String {
-    type Error = GAErrors;
+    type Error = ErrorHolder;
 
-    fn try_from(setting: Setting) -> CoreResult<Self, Self::Error> {
-        match setting.type_constraint {
-            TypeConstraint::String => Ok(setting.value.ok_or(TypeConstraintViolated("None"))?),
-            _ => Err(TypeConstraintViolated("method: try_from<String>"))
-        }
+    fn try_from(setting: Setting) -> StdResult<Self, Self::Error> {
+        (|| match setting.type_constraint {
+            TypeConstraint::String => Ok(setting.value.ok_or_else(|| anyhow!("Value for String setting `{}` is not set", setting))?),
+            _ => bail!("Tried to cast setting `{}` into string despite it being {}", setting, setting.type_constraint)
+        })().map_err(|err| ErrorHolder(err))
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,7 +99,7 @@ pub(crate) async fn init(db_pool: &Pool<Postgres>) -> Result<()> {
 
                 info!("Required database tables do not exist. Creating...");
 
-                create_tables(&db_pool).await?;
+                create_tables(db_pool).await?;
                 return Ok(());
             }
         }
@@ -185,7 +185,7 @@ impl TryFrom<Setting> for bool {
                 }
             }
             _ => bail!("Tried to cast setting `{}` into boolean despite it being {}", setting.key.as_str(), setting.type_constraint)
-        })().map_err(|err| ErrorHolder(err))
+        })().map_err(ErrorHolder)
     }
 }
 
@@ -196,7 +196,7 @@ impl TryFrom<Setting> for String {
         (|| match setting.type_constraint {
             TypeConstraint::String => Ok(setting.value.ok_or_else(|| anyhow!("Value for String setting `{}` is not set", setting.key.as_str()))?),
             _ => bail!("Tried to cast setting `{}` into string despite it being {}", setting.key.as_str(), setting.type_constraint)
-        })().map_err(|err| ErrorHolder(err))
+        })().map_err(ErrorHolder)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,10 +160,10 @@ macro_rules! generate_try_from {
             fn try_from(setting: Setting) -> StdResult<$type_, Self::Error> {
                 (|| match setting.type_constraint {
                     TypeConstraint::$type_constraint => {
-                        let str = setting.value.ok_or_else(|| anyhow!("Value for {} setting `{}` is not set", stringify!($type_constraint), setting))?;
-                        <$type_>::from_str(&str).map_err(|err| anyhow!("Expected valid value for {} on setting `{}` but instead received `{:?}`: {}", stringify!($type_constraint), setting, setting.value, err))
+                        let str = setting.value.as_ref().ok_or_else(|| anyhow!("Value for {} setting `{}` is not set", stringify!($type_constraint), setting))?;
+                        <$type_>::from_str(str).map_err(|err| anyhow!("Expected valid value for {} on setting `{}` but instead received `{:?}`: {}", stringify!($type_constraint), setting.key.as_str(), setting.value, err))
                     },
-                    _ => bail!("Tried to cast setting `{}` into {} despite it being {}", setting, stringify!($type_constraint), setting.type_constraint)
+                    _ => bail!("Tried to cast setting `{}` into {} despite it being {}", setting.key.as_str(), stringify!($type_constraint), setting.type_constraint)
                 })().map_err(|err| ErrorHolder(err))
             }
         }
@@ -176,15 +176,15 @@ impl TryFrom<Setting> for bool {
     fn try_from(setting: Setting) -> StdResult<bool, Self::Error> {
         (|| match setting.type_constraint {
             TypeConstraint::Boolean => {
-                let str = setting.value.ok_or_else(|| anyhow!("Value for Boolean setting `{}` is not set", setting))?;
+                let str = setting.value.ok_or_else(|| anyhow!("Value for Boolean setting `{}` is not set", setting.key.as_str()))?;
 
                 match str.to_lowercase().as_str() {
                     "1" | "true" => Ok(true),
                     "0" | "false" => Ok(false),
-                    _ => bail!("Expected valid value for boolean on setting `{}` but instead received `{}`", setting, str)
+                    _ => bail!("Expected valid value for boolean on setting `{}` but instead received `{}`", setting.key.as_str(), str.as_str())
                 }
             }
-            _ => bail!("Tried to cast setting `{}` into boolean despite it being {}", setting, setting.type_constraint)
+            _ => bail!("Tried to cast setting `{}` into boolean despite it being {}", setting.key.as_str(), setting.type_constraint)
         })().map_err(|err| ErrorHolder(err))
     }
 }
@@ -194,8 +194,8 @@ impl TryFrom<Setting> for String {
 
     fn try_from(setting: Setting) -> StdResult<Self, Self::Error> {
         (|| match setting.type_constraint {
-            TypeConstraint::String => Ok(setting.value.ok_or_else(|| anyhow!("Value for String setting `{}` is not set", setting))?),
-            _ => bail!("Tried to cast setting `{}` into string despite it being {}", setting, setting.type_constraint)
+            TypeConstraint::String => Ok(setting.value.ok_or_else(|| anyhow!("Value for String setting `{}` is not set", setting.key.as_str()))?),
+            _ => bail!("Tried to cast setting `{}` into string despite it being {}", setting.key.as_str(), setting.type_constraint)
         })().map_err(|err| ErrorHolder(err))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,156 +1,176 @@
 use crate::git::io::band::Band;
 use crate::git::io::writer::GitWriter;
+use crate::templates;
 
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
 use actix_web::dev::HttpResponseBuilder;
-use actix_web::error::ResponseError;
+use actix_web::error::{InternalError, PrivateHelper};
 use actix_web::http::StatusCode;
-use actix_web::HttpResponse;
-use anyhow::Error as AnyhowError;
-use anyhow::Result as AnyhowResult;
+use actix_web::{HttpResponse, ResponseError};
+use anyhow::{Error, Result};
 use async_compat::Compat;
+use derive_more::{Display, Error};
 use futures::executor;
 use log::error;
-use serde::ser::SerializeStruct;
-use serde::{Serialize, Serializer};
 use serde_json::json;
-use thiserror::Error;
+use tera::Context;
 
-#[derive(Error, Debug)]
-pub(crate) enum GAErrors {
-    #[error("{1}")]
-    HttpError(u16, String),
+macro_rules! die {
+    ($code:expr) => {
+        return Err($crate::error::WithStatusCode::new(actix_web::http::StatusCode::$code).into());
+    }
+    ($code:literal) => {{
+        use anyhow::Context as _;
 
-    #[error("{1}")]
-    PlainError(u16, String),
-
-    #[error("(null)")]
-    GitError(u16, Option<String>),
-
-    #[error("Unable to parse {0} from `{1}`")]
-    ParseError(&'static str, String),
-
-    #[error("Unable to unpack {0} for pack")]
-    PackUnpackError(&'static str),
-
-    #[error("Error occurred when trying to run hook: {0}")]
-    HookError(&'static str),
-
-    #[error("Type constraint was violated on {0}")]
-    TypeConstraintViolated(&'static str),
-
-    #[error("Not authenticated. Try logging in")]
-    NotAuthenticated
+        return Err($crate::error::WithStatusCode::try_new($code).context("Tried to die with invalid status code")?.into());
+    }}
+    ($code:expr, $message:literal) => {
+        return Err($crate::error::WithStatusCode {
+            code: actix_web::http::StatusCode::$code,
+            source: anyhow::anyhow!($message),
+            display: false
+        })
+    }
+    ($err:expr $(,)?) => ({
+        return Err($crate::error::WithStatusCode {
+            code: actix_web::http::StatusCode::$code,
+            source: anyhow::anyhow!($err),
+            display: false
+        })
+    })
+    ($code:expr, $fmt:literal, $($arg:tt)*) => {
+        return Err($crate::error::WithStatusCode {
+            code: actix_web::http::StatusCode::$code,
+            source: anyhow::anyhow!($fmt, $($arg)*),
+            display: true
+        })
+    }
 }
 
-impl From<GAErrors> for GitArenaError {
-    fn from(ga_error: GAErrors) -> Self {
-        GitArenaError {
-            error: ga_error.into()
+#[derive(Debug, Display, Error)]
+#[display("http status {} caused by {}", code, source)]
+pub(crate) struct WithStatusCode {
+    code: StatusCode,
+    source: Option<Error>,
+    display: bool // Whenever cause() should be shown to the user
+}
+
+impl WithStatusCode {
+    pub(crate) fn new(code: StatusCode) -> WithStatusCode {
+        WithStatusCode {
+            code,
+            source: None,
+            display: false
         }
     }
-}
 
-pub(crate) struct GitArenaError {
-    error: AnyhowError
-}
-
-impl Display for GitArenaError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}", self.error)
+    pub(crate) fn try_new(code: u16) -> Result<WithStatusCode> {
+        Ok(WithStatusCode {
+            code: StatusCode::from_u16(code)?,
+            source: None,
+            display: false
+        })
     }
+}
+
+#[derive(Clone)]
+pub(crate) struct GitArenaError {
+    source: Error,
+    display_type: ErrorDisplayType
 }
 
 impl Debug for GitArenaError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{:?}", self.error)
+        Debug::fmt(&self.source, f)
     }
 }
 
-impl Serialize for GitArenaError {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-    {
-        let cause = format!("{}", self.error);
-
-        let mut state = serializer.serialize_struct("GitArenaError", 1)?;
-        state.serialize_field("error", cause.as_str())?;
-        state.end()
-    }
-}
-
-impl From<AnyhowError> for GitArenaError {
-    fn from(error: AnyhowError) -> Self {
-        GitArenaError { error }
+impl Display for GitArenaError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.source, f)
     }
 }
 
 impl ResponseError for GitArenaError {
     fn status_code(&self) -> StatusCode {
-        if let Some(e) = self.error.downcast_ref::<GAErrors>() {
-            match e {
-                GAErrors::HttpError(status_code, _) => StatusCode::from_u16(*status_code),
-                GAErrors::PlainError(status_code, _) => StatusCode::from_u16(*status_code),
-                GAErrors::GitError(status_code, _) => StatusCode::from_u16(*status_code),
-                GAErrors::NotAuthenticated => Ok(StatusCode::UNAUTHORIZED),
-
-                _ => Ok(StatusCode::INTERNAL_SERVER_ERROR)
-            }.unwrap_or_else(|error| {
-                panic!("Invalid status code passed to GitArena error: {}", error);
-            })
-        } else {
-            StatusCode::INTERNAL_SERVER_ERROR
+        match self.source.downcast_ref::<WithStatusCode>() {
+            Some(with_code) => with_code.code,
+            None => StatusCode::INTERNAL_SERVER_ERROR
         }
     }
 
     fn error_response(&self) -> HttpResponse {
-        if let Some(gitarena_error) = self.error.downcast_ref::<GAErrors>() {
-            return match gitarena_error {
-                GAErrors::HttpError(_, message) => {
-                    HttpResponseBuilder::new(self.status_code())
-                        .json(json!({
-                            "error": message
-                        }))
-                }
-                GAErrors::PlainError(_, message) => HttpResponseBuilder::new(self.status_code()).body(message),
-                GAErrors::GitError(_, message_option) => {
-                    match message_option {
-                        Some(message) => {
-                            // TODO: Refactor this to no longer block the whole thread
-                            let response: AnyhowResult<HttpResponse> = executor::block_on(Compat::new(async {
-                                let mut writer = GitWriter::new();
-                                writer.write_text_sideband(Band::Error, format!("error: {}", message)).await?;
+        let mut builder = HttpResponseBuilder::new(self.status_code());
 
-                                let response = writer.serialize().await?;
+        let display = self.source.downcast_ref::<WithStatusCode>().map_or_else(|| false, |w| w.display);
+        let message = if display {
+            self.source.to_string()
+        } else {
+            self.status_code().canonical_reason().unwrap_or_default().to_string()
+        };
 
-                                // Git doesn't show client errors if the response isn't 200 for some reason
-                                Ok(HttpResponse::Ok().body(response))
-                            }));
+        match &self.display_type {
+            ErrorDisplayType::Html | ErrorDisplayType::Git => {
+                // TODO: Refactor this to no longer block the whole thread
+                executor::block_on(Compat::new(async {
+                    render_error_async(&self, builder, message.as_str()).await
+                }))
+            },
+            ErrorDisplayType::Htmx(inner) => {
+                // TODO: Send partial htmx instead
+                let mut error = self.clone();
+                error.display_type = **inner;
 
-                            response.unwrap_or_else(|err| {
-                                error!("In addition, another error occurred while handling the previous error: {}", err);
-                                HttpResponse::InternalServerError().finish()
-                            })
-                        }
-                        None => HttpResponseBuilder::new(self.status_code()).finish()
-                    }
-                },
-                GAErrors::NotAuthenticated => {
-                    HttpResponse::Unauthorized()
-                        .json(json!({
-                            "error": "Not logged in"
-                        }))
-                },
-
-                _ => HttpResponse::InternalServerError().finish()
+                error.error_response()
             }
+            ErrorDisplayType::Json => builder.json(json!({
+                "error": message
+            })),
+            ErrorDisplayType::Plain => builder.body(message)
         }
-
-        HttpResponse::InternalServerError()
-            .json(json!({
-                "error": "Internal server error occurred"
-            }))
     }
+}
+
+async fn render_error_async(renderer: &GitArenaError, builder: HttpResponseBuilder, message: &str) -> HttpResponse {
+    match renderer.display_type {
+        ErrorDisplayType::Html => render_html_error(renderer.status_code(), message).await,
+        ErrorDisplayType::Git => render_git_error(message).await,
+        _ => unreachable!("Only html and git errors require async handling")
+    }.unwrap_or_else(|err| {
+        error!("In addition, another error occurred while handling the previous error: {}", err);
+        InternalError::new(err, StatusCode::INTERNAL_SERVER_ERROR).into()
+    })
+}
+
+async fn render_html_error(code: StatusCode, message: &str, display: bool) -> Result<HttpResponse> {
+    let mut context = Context::new();
+    context.try_insert("error", message)?;
+
+    if cfg!(debug_assertions) {
+        context.try_insert("debug", &true)?;
+    }
+
+    let template_name = format!("error/{}.html", code.as_u16());
+    let template = templates::TERA.read().await.render(template_name.as_str(), &context)?;
+
+    Ok(HttpResponseBuilder::new(code).body(template))
+}
+
+async fn render_git_error(message: &str) -> Result<HttpResponse> {
+    let mut writer = GitWriter::new();
+    writer.write_text_sideband(Band::Error, format!("error: {}", message)).await?;
+
+    let response = writer.serialize().await?;
+
+    // Git doesn't show client errors if the response isn't 200 for some reason
+    Ok(HttpResponse::Ok().body(response))
+}
+
+pub(crate) enum ErrorDisplayType {
+    Html,
+    Htmx(Box<ErrorDisplayType>),
+    Json,
+    Git,
+    Plain
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -163,6 +163,7 @@ impl ResponseError for GitArenaError {
         }
     }
 
+    #[allow(clippy::async_yields_async)] // False positive on this method
     fn error_response(&self) -> HttpResponse {
         let mut builder = HttpResponseBuilder::new(self.status_code());
 
@@ -177,7 +178,7 @@ impl ResponseError for GitArenaError {
             ErrorDisplayType::Html | ErrorDisplayType::Git => {
                 // TODO: Refactor this to no longer block the whole thread
                 executor::block_on(Compat::new(async {
-                    render_error_async(&self, message.as_str()).await
+                    render_error_async(self, message.as_str()).await
                 }))
             },
             ErrorDisplayType::Htmx(inner) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ use tera::Context;
 
 #[macro_export]
 macro_rules! die {
-    ($code:expr) => {
+    ($code:ident) => {
         return Err($crate::error::WithStatusCode::new(actix_web::http::StatusCode::$code).into());
     };
     ($code:literal) => {{
@@ -28,26 +28,26 @@ macro_rules! die {
 
         return Err($crate::error::WithStatusCode::try_new($code).context("Tried to die with invalid status code")?.into());
     }};
-    ($code:expr, $message:literal) => {
+    ($code:ident, $message:literal) => {
         return Err($crate::error::WithStatusCode {
             code: actix_web::http::StatusCode::$code,
-            source: anyhow::anyhow!($message),
+            source: Some(anyhow::anyhow!($message)),
             display: true
-        })
+        }.into());
     };
     ($err:expr $(,)?) => ({
         return Err($crate::error::WithStatusCode {
-            code: actix_web::http::StatusCode::$code,
-            source: anyhow::anyhow!($err),
-            display: true
-        })
+            code: actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+            source: Some(anyhow::anyhow!($err)),
+            display: false
+        }.into());
     });
-    ($code:expr, $fmt:literal, $($arg:tt)*) => {
+    ($code:ident, $fmt:literal, $($arg:tt)*) => {
         return Err($crate::error::WithStatusCode {
             code: actix_web::http::StatusCode::$code,
-            source: anyhow::anyhow!($fmt, $($arg)*),
+            source: Some(anyhow::anyhow!($fmt, $($arg)*)),
             display: true
-        })
+        }.into());
     };
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,7 @@ use tera::Context;
 #[macro_export]
 macro_rules! die {
     ($($input:tt)*) => {
-        return Err($crate::err!($($input)*).into());
+        return Err($crate::err!($($input)*).into())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@ use log::error;
 use serde_json::json;
 use tera::Context;
 
+#[macro_export]
 macro_rules! die {
     ($code:expr) => {
         return Err($crate::error::WithStatusCode::new(actix_web::http::StatusCode::$code).into());
@@ -31,14 +32,14 @@ macro_rules! die {
         return Err($crate::error::WithStatusCode {
             code: actix_web::http::StatusCode::$code,
             source: anyhow::anyhow!($message),
-            display: false
+            display: true
         })
     };
     ($err:expr $(,)?) => ({
         return Err($crate::error::WithStatusCode {
             code: actix_web::http::StatusCode::$code,
             source: anyhow::anyhow!($err),
-            display: false
+            display: true
         })
     });
     ($code:expr, $fmt:literal, $($arg:tt)*) => {

--- a/src/git/basic_auth.rs
+++ b/src/git/basic_auth.rs
@@ -1,7 +1,5 @@
-use crate::crypto;
-use crate::error::GAErrors::{GitError, PlainError};
+use crate::{crypto, die};
 use crate::git::basic_auth;
-use crate::mail::Email;
 use crate::prelude::*;
 use crate::privileges::repo_visibility::RepoVisibility;
 use crate::repository::Repository;
@@ -32,7 +30,7 @@ pub(crate) async fn validate_repo_access<'e, E>(repo: Option<Repository>, conten
             // Prompt for authentication even if the repo does not exist to prevent leakage of private repositories
             let _ = login_flow(request, executor, content_type).await?;
 
-            Err(GitError(404, None).into())
+            die!(NOT_FOUND, "Repository not found");
         }
     }
 }
@@ -68,7 +66,7 @@ pub(crate) async fn authenticate<'e, E>(request: &HttpRequest, transaction: E) -
             let (username, password) = parse_basic_auth(auth_header).await?;
 
             if username.is_empty() || password.is_empty() {
-                return Err(PlainError(401, "Username and password cannot be empty".to_owned()).into());
+                die!(UNAUTHORIZED, "Username and password cannot be empty");
             }
 
             let option: Option<User> = sqlx::query_as::<_, User>("select * from users where username = $1 limit 1")
@@ -77,29 +75,27 @@ pub(crate) async fn authenticate<'e, E>(request: &HttpRequest, transaction: E) -
                 .await?;
 
             if option.is_none() {
-                return Err(PlainError(401, "User does not exist".to_owned()).into());
+                die!(UNAUTHORIZED, "User does not exist");
             }
 
             let user = option.unwrap_or_log();
 
             if !crypto::check_password(&user, &password)? {
-                return Err(PlainError(401, "Incorrect password".to_owned()).into());
+                die!(UNAUTHORIZED, "Incorrect password");
             }
 
             // TODO: Check for allowed login
             /*let primary_email = Email::find_primary_email(&user, transaction)
                 .await?
-                .ok_or_else(|| PlainError(401, "No primary email".to_owned()))?;*/
+                .ok_or_else(|| anyhow!("No primary email".to_owned()))?;*/
 
             if user.disabled/* || !primary_email.is_allowed_login()*/ {
-                return Err(PlainError(401, "Account has been disabled. Please contact support.".to_owned()).into());
+                die!(UNAUTHORIZED, "Account has been disabled. Please contact support.");
             }
 
             Ok(user)
         }
-        None => {
-            Err(GitError(401, None).into())
-        }
+        None => die!(UNAUTHORIZED)
     }
 }
 
@@ -110,7 +106,7 @@ pub(crate) async fn parse_basic_auth(auth_header: &str) -> Result<(String, Strin
     let base64_creds = split.next().unwrap_or_default();
 
     if auth_type != "Basic" {
-        return Err(GitError(401, None).into());
+        die!(UNAUTHORIZED);
     }
 
     let creds = String::from_utf8(base64::decode(base64_creds)?)?;
@@ -120,7 +116,7 @@ pub(crate) async fn parse_basic_auth(auth_header: &str) -> Result<(String, Strin
     let password = splitted_creds.next().unwrap_or_default();
 
     if username.is_empty() || password.is_empty() {
-        return Err(PlainError(401, "Username and password cannot be empty".to_owned()).into());
+        die!(UNAUTHORIZED, "Username and password cannot be empty");
     }
 
     Ok((username.to_owned(), password.to_owned()))

--- a/src/git/basic_auth.rs
+++ b/src/git/basic_auth.rs
@@ -39,11 +39,11 @@ pub(crate) async fn validate_repo_access<'e, E>(repo: Option<Repository>, conten
 pub(crate) async fn login_flow<'e, E>(request: &HttpRequest, executor: E, content_type: &str) -> Result<Either<User, HttpResponse>>
     where E: Executor<'e, Database = Postgres>
 {
-    if !basic_auth::is_present(&request).await {
+    if !basic_auth::is_present(request).await {
         return Ok(Either::B(prompt(content_type).await));
     }
 
-    Ok(Either::A(basic_auth::authenticate(&request, executor).await?))
+    Ok(Either::A(basic_auth::authenticate(request, executor).await?))
 }
 
 #[allow(clippy::async_yields_async)] // False positive on this method
@@ -101,7 +101,7 @@ pub(crate) async fn authenticate<'e, E>(request: &HttpRequest, transaction: E) -
 
 #[instrument(skip(auth_header), err)]
 pub(crate) async fn parse_basic_auth(auth_header: &str) -> Result<(String, String)> {
-    let mut split = auth_header.splitn(2, " ");
+    let mut split = auth_header.splitn(2, ' ');
     let auth_type = split.next().unwrap_or_default();
     let base64_creds = split.next().unwrap_or_default();
 
@@ -110,7 +110,7 @@ pub(crate) async fn parse_basic_auth(auth_header: &str) -> Result<(String, Strin
     }
 
     let creds = String::from_utf8(base64::decode(base64_creds)?)?;
-    let mut splitted_creds = creds.splitn(2, ":");
+    let mut splitted_creds = creds.splitn(2, ':');
 
     let username = splitted_creds.next().unwrap_or_default();
     let password = splitted_creds.next().unwrap_or_default();

--- a/src/git/io/band.rs
+++ b/src/git/io/band.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use derive_more::Display;
 
 #[derive(Display, Debug)]

--- a/src/git/io/reader.rs
+++ b/src/git/io/reader.rs
@@ -1,6 +1,4 @@
-use crate::error::GAErrors::ParseError;
-
-use anyhow::Result;
+use anyhow::{bail, Result};
 use git_repository::protocol::transport::packetline::{PacketLineRef, StreamingPeekableIter};
 use log::warn;
 use tracing::instrument;
@@ -26,14 +24,14 @@ pub(crate) async fn read_until_command(mut body: Vec<Vec<u8>>) -> Result<(String
                     None => continue
                 }
             }
-            Err(e) => {
-                warn!("Failed to read line into UTF-8 vec: {}", e);
+            Err(err) => {
+                warn!("Failed to read line into UTF-8 vec: {}", err);
                 continue;
             }
         }
     }
 
-    Err(ParseError("Git request body", String::new()).into())
+    bail!("Unable to parse Git request body")
 }
 
 #[instrument(err, skip(iter))]

--- a/src/git/pack.rs
+++ b/src/git/pack.rs
@@ -1,11 +1,10 @@
-use crate::error::GAErrors::PackUnpackError;
 use crate::repository::Repository;
 
 use std::io::BufReader;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use git_repository::odb::pack::bundle::write::Options as GitPackWriteOptions;
 use git_repository::odb::pack::data::input::{Mode as PackIterationMode};
 use git_repository::odb::pack::index::Version as PackVersion;
@@ -53,8 +52,8 @@ pub(crate) async fn write_to_fs<'e, E: Executor<'e, Database = Postgres>>(data: 
         options
     )?;
 
-    let index_path = bundle.index_path.ok_or(PackUnpackError("index file"))?;
-    let data_path = bundle.data_path.ok_or(PackUnpackError("data file"))?;
+    let index_path = bundle.index_path.ok_or_else(|| anyhow!("Failed to unpack index file"))?;
+    let data_path = bundle.data_path.ok_or_else(|| anyhow!("Failed to unpack data file"))?;
 
     Ok((index_path, data_path))
 }

--- a/src/git/receive_pack.rs
+++ b/src/git/receive_pack.rs
@@ -1,4 +1,3 @@
-use crate::error::WithStatusCode;
 use crate::git::GitoxideCacheList;
 use crate::git::io::band::Band;
 use crate::git::io::writer::GitWriter;
@@ -12,7 +11,6 @@ use std::convert::TryInto;
 use std::io::Write;
 use std::path::PathBuf;
 
-use actix_web::http::StatusCode;
 use anyhow::{anyhow, Result};
 use bstr::BString;
 use git_repository::actor::Signature;
@@ -162,7 +160,7 @@ pub(crate) async fn process_delete<'e, E: Executor<'e, Database = Postgres>>(ref
 
     gitoxide_repo.refs.transaction()
         .prepare(edits, Fail::Immediately)
-        .map_err(|e| GitError(500, Some(format!("Failed to commit transaction: {}", e))))?
+        .map_err(|err| err!(INTERNAL_SERVER_ERROR, "Failed to commit transaction: {}", err))?
         .commit(&Signature::gitarena_default())?;
 
     if ref_update.report_status || ref_update.report_status_v2 {

--- a/src/git/receive_pack.rs
+++ b/src/git/receive_pack.rs
@@ -1,4 +1,4 @@
-use crate::error::GAErrors::{GitError, PackUnpackError};
+use crate::error::WithStatusCode;
 use crate::git::GitoxideCacheList;
 use crate::git::io::band::Band;
 use crate::git::io::writer::GitWriter;
@@ -6,12 +6,14 @@ use crate::git::ref_update::RefUpdate;
 use crate::prelude::*;
 use crate::repository::Repository;
 use crate::utils::oid;
+use crate::{die, err};
 
 use std::convert::TryInto;
 use std::io::Write;
 use std::path::PathBuf;
 
-use anyhow::Result;
+use actix_web::http::StatusCode;
+use anyhow::{anyhow, Result};
 use bstr::BString;
 use git_repository::actor::Signature;
 use git_repository::lock::acquire::Fail;
@@ -43,7 +45,7 @@ pub(crate) async fn process_create_update(ref_update: &RefUpdate, repo: &Reposit
             (Some(index_path), Some(pack_path)) => {
                 let index_file = IndexFile::at(index_path)?;
 
-                let index = index_file.lookup(new_oid.as_ref()).ok_or(PackUnpackError("oid index"))?;
+                let index = index_file.lookup(new_oid.as_ref()).ok_or_else(|| anyhow!("Failed to lookup new oid in index file"))?;
                 let offset = index_file.pack_offset_at_index(index);
 
                 let data_file = DataFile::at(pack_path)?;
@@ -76,7 +78,7 @@ pub(crate) async fn process_create_update(ref_update: &RefUpdate, repo: &Reposit
 
                 match outcome.kind {
                     Kind::Commit => CommitRef::from_bytes(buffer.as_slice())?,
-                    _ => return Err(GitError(400, Some("Unexpected payload data type".to_owned())).into())
+                    _ => die!(BAD_REQUEST, "Unexpected payload data type")
                 }
             },
             _ => {
@@ -113,7 +115,7 @@ pub(crate) async fn process_create_update(ref_update: &RefUpdate, repo: &Reposit
 
         gitoxide_repo.refs.transaction()
             .prepare(edits, Fail::Immediately)
-            .map_err(|e| GitError(500, Some(format!("Failed to commit transaction: {}", e))))?
+            .map_err(|err| anyhow!("Failed to commit transaction: {}", err))?
             .commit(&Signature::from(commit.committer))?;
     }
 
@@ -145,7 +147,7 @@ pub(crate) async fn process_delete<'e, E: Executor<'e, Database = Postgres>>(ref
 
     let gitoxide_repo = repo.gitoxide(executor).await?;
 
-    let object_id = oid::from_hex_str(ref_update.old.as_deref()).map_err(|_| GitError(404, Some("Ref does not exist".to_owned())))?;
+    let object_id = oid::from_hex_str(ref_update.old.as_deref()).map_err(|_| err!(NOT_FOUND, "Ref does not exist"))?;
 
     let edits = vec![
         RefEdit {

--- a/src/privileges/repo_visibility.rs
+++ b/src/privileges/repo_visibility.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use sqlx::Type;

--- a/src/routes/admin/dashboard.rs
+++ b/src/routes/admin/dashboard.rs
@@ -1,5 +1,4 @@
-use crate::error::GAErrors::HttpError;
-use crate::render_template;
+use crate::{die, render_template};
 use crate::repository::Repository;
 use crate::user::{User, WebUser};
 
@@ -18,7 +17,7 @@ pub(crate) async fn dashboard(web_user: WebUser, db_pool: web::Data<PgPool>) -> 
     let user = web_user.into_user()?;
 
     if !user.admin {
-        return Err(HttpError(403, "Not allowed".to_owned()).into());
+        die!(FORBIDDEN, "Not allowed");
     }
 
     let mut context = Context::new();

--- a/src/routes/admin/dashboard.rs
+++ b/src/routes/admin/dashboard.rs
@@ -13,7 +13,7 @@ use heim::units::{Information, information, Time};
 use sqlx::PgPool;
 use tera::Context;
 
-#[route("/", method = "GET")]
+#[route("/", method = "GET", err = "html")]
 pub(crate) async fn dashboard(web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let user = web_user.into_user()?;
 

--- a/src/routes/admin/settings.rs
+++ b/src/routes/admin/settings.rs
@@ -14,7 +14,7 @@ use multimap::MultiMap;
 use sqlx::PgPool;
 use tera::Context;
 
-#[route("/settings", method = "GET")]
+#[route("/settings", method = "GET", err = "html")]
 pub(crate) async fn get_settings(web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let user = web_user.into_user()?;
 
@@ -45,7 +45,7 @@ pub(crate) async fn get_settings(web_user: WebUser, db_pool: web::Data<PgPool>) 
     render_template!("admin/settings.html", context, transaction)
 }
 
-#[route("/settings", method = "PATCH")]
+#[route("/settings", method = "PATCH", err = "htmx+text")]
 pub(crate) async fn patch_settings(data: web::Form<HashMap<String, String>>, web_user: WebUser, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let user = web_user.into_user()?;
 

--- a/src/routes/proxy/img_proxy.rs
+++ b/src/routes/proxy/img_proxy.rs
@@ -66,7 +66,7 @@ const ACCEPTED_MIME_TYPES: [&'static str; 43] = [
     "image/x-xwindowdump"
 ];
 
-#[route("/api/proxy/{url}", method="GET")]
+#[route("/api/proxy/{url}", method = "GET", err = "text")]
 pub(crate) async fn proxy(uri: web::Path<ProxyRequest>, request: HttpRequest) -> Result<impl Responder> {
     let url = &uri.url;
 

--- a/src/routes/repository/api/create_repo.rs
+++ b/src/routes/repository/api/create_repo.rs
@@ -12,7 +12,7 @@ use gitarena_macros::route;
 use serde::{Deserialize, Serialize};
 use log::info;
 
-#[route("/api/repo", method="POST")]
+#[route("/api/repo", method = "POST", err = "json")]
 pub(crate) async fn create(web_user: WebUser, body: web::Json<CreateJsonRequest>, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 

--- a/src/routes/repository/api/repo_meta.rs
+++ b/src/routes/repository/api/repo_meta.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use gitarena_macros::route;
 use sqlx::PgPool;
 
-#[route("/api/repo/{username}/{repository}", method="GET")]
+#[route("/api/repo/{username}/{repository}", method = "GET", err = "json")]
 pub(crate) async fn meta(uri: web::Path<GitRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 

--- a/src/routes/repository/api/repo_readme.rs
+++ b/src/routes/repository/api/repo_readme.rs
@@ -15,7 +15,7 @@ use gitarena_macros::route;
 use serde_json::json;
 use sqlx::PgPool;
 
-#[route("/api/repo/{username}/{repository}/tree/{tree:.*}/readme", method="GET")]
+#[route("/api/repo/{username}/{repository}/tree/{tree:.*}/readme", method = "GET", err = "json")]
 pub(crate) async fn readme(uri: web::Path<GitTreeRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 

--- a/src/routes/repository/api/repo_readme.rs
+++ b/src/routes/repository/api/repo_readme.rs
@@ -1,10 +1,10 @@
-use crate::error::GAErrors::HttpError;
 use crate::git::GitoxideCacheList;
 use crate::git::utils::{read_blob_content, repo_files_at_ref};
 use crate::privileges::privilege;
 use crate::repository::Repository;
 use crate::routes::repository::GitTreeRequest;
 use crate::user::{User, WebUser};
+use crate::{die, err};
 
 use actix_web::{HttpResponse, Responder, web};
 use anyhow::Result;
@@ -19,11 +19,11 @@ use sqlx::PgPool;
 pub(crate) async fn readme(uri: web::Path<GitTreeRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 
-    let repo_owner = User::find_using_name(&uri.username, &mut transaction).await.ok_or_else(|| HttpError(404, "Repository not found".to_owned()))?;
-    let repo = Repository::open(repo_owner, &uri.repository, &mut transaction).await.ok_or_else(|| HttpError(404, "Repository not found".to_owned()))?;
+    let repo_owner = User::find_using_name(&uri.username, &mut transaction).await.ok_or_else(|| err!(NOT_FOUND, "Repository not found"))?;
+    let repo = Repository::open(repo_owner, &uri.repository, &mut transaction).await.ok_or_else(|| err!(NOT_FOUND, "Repository not found"))?;
 
     if !privilege::check_access(&repo, web_user.as_ref(), &mut transaction).await? {
-        return Err(HttpError(404, "Not found".to_owned()).into());
+        die!(NOT_FOUND, "Not found");
     }
 
     let gitoxide_repo = repo.gitoxide(&mut transaction).await?;
@@ -31,7 +31,7 @@ pub(crate) async fn readme(uri: web::Path<GitTreeRequest>, web_user: WebUser, db
     let loose_ref = match gitoxide_repo.refs.find_loose(uri.tree.as_str()) {
         Ok(loose_ref) => Ok(loose_ref),
         Err(GitoxideFindError::Find(err)) => Err(err),
-        Err(GitoxideFindError::NotFound(_)) => return Err(HttpError(404, "Tree not found".to_owned()).into())
+        Err(GitoxideFindError::NotFound(_)) => die!(NOT_FOUND, "Tree not found")
     }?;
 
     let mut buffer = Vec::<u8>::new();
@@ -43,7 +43,7 @@ pub(crate) async fn readme(uri: web::Path<GitTreeRequest>, web_user: WebUser, db
     let entry = tree.entries
         .iter()
         .find(|e| e.filename.to_lowercase().starts_with(b"readme"))
-        .ok_or_else(|| HttpError(404, "No README found".to_owned()))?;
+        .ok_or_else(|| err!(NOT_FOUND, "No readme file found"))?;
 
     let name = entry.filename.to_str().unwrap_or("Invalid file name");
 

--- a/src/routes/repository/api/star.rs
+++ b/src/routes/repository/api/star.rs
@@ -12,7 +12,7 @@ use log::debug;
 use serde_json::json;
 use sqlx::{Executor, PgPool, Postgres};
 
-#[route("/api/repo/{username}/{repository}/star", method = "GET")]
+#[route("/api/repo/{username}/{repository}/star", method = "GET", err = "htmx+json")]
 pub(crate) async fn get_star(uri: web::Path<GitRequest>, web_user: WebUser, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 
@@ -44,7 +44,7 @@ pub(crate) async fn get_star(uri: web::Path<GitRequest>, web_user: WebUser, requ
     }
 }
 
-#[route("/api/repo/{username}/{repository}/star", method = "POST")]
+#[route("/api/repo/{username}/{repository}/star", method = "POST", err = "json")]
 pub(crate) async fn post_star(uri: web::Path<GitRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let user = web_user.into_user()?;
 
@@ -68,7 +68,7 @@ pub(crate) async fn post_star(uri: web::Path<GitRequest>, web_user: WebUser, db_
     Ok(HttpResponse::Created().finish())
 }
 
-#[route("/api/repo/{username}/{repository}/star", method = "DELETE")]
+#[route("/api/repo/{username}/{repository}/star", method = "DELETE", err = "json")]
 pub(crate) async fn delete_star(uri: web::Path<GitRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let user = web_user.into_user()?;
 
@@ -92,7 +92,7 @@ pub(crate) async fn delete_star(uri: web::Path<GitRequest>, web_user: WebUser, d
     Ok(HttpResponse::NoContent().finish())
 }
 
-#[route("/api/repo/{username}/{repository}/star", method = "PUT")]
+#[route("/api/repo/{username}/{repository}/star", method = "PUT", err = "text")]
 pub(crate) async fn put_star(uri: web::Path<GitRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let user = web_user.into_user()?;
 

--- a/src/routes/repository/archive.rs
+++ b/src/routes/repository/archive.rs
@@ -28,7 +28,7 @@ use tokio_tar::{Builder as TarBuilder, Header as TarHeader};
 use zip::write::FileOptions as ZipFileOptions;
 use zip::ZipWriter;
 
-#[route("/{username}/{repository}/tree/{tree:.*}/archive/targz", method="GET")]
+#[route("/{username}/{repository}/tree/{tree:.*}/archive/targz", method = "GET", err = "html")]
 pub(crate) async fn tar_gz_file(uri: web::Path<GitTreeRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 
@@ -120,7 +120,7 @@ async fn write_directory_tar(repo: &GitoxideRepository, tree: Tree, path: &Path,
     Ok(())
 }
 
-#[route("/{username}/{repository}/tree/{tree:.*}/archive/zip", method="GET")]
+#[route("/{username}/{repository}/tree/{tree:.*}/archive/zip", method = "GET", err = "html")]
 pub(crate) async fn zip_file(uri: web::Path<GitTreeRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 

--- a/src/routes/repository/commits.rs
+++ b/src/routes/repository/commits.rs
@@ -16,7 +16,7 @@ use gitarena_macros::route;
 use sqlx::PgPool;
 use tera::Context;
 
-#[route("/{username}/{repository}/tree/{tree:.*}/commits", method = "GET")]
+#[route("/{username}/{repository}/tree/{tree:.*}/commits", method = "GET", err = "htmx+html")]
 pub(crate) async fn commits(uri: web::Path<GitTreeRequest>, web_user: WebUser, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 

--- a/src/routes/repository/git/git_receive_pack.rs
+++ b/src/routes/repository/git/git_receive_pack.rs
@@ -23,7 +23,7 @@ use log::warn;
 use memmem::{Searcher, TwoWaySearcher};
 use sqlx::PgPool;
 
-#[route("/{username}/{repository}.git/git-receive-pack", method="POST")]
+#[route("/{username}/{repository}.git/git-receive-pack", method = "POST", err = "git")]
 pub(crate) async fn git_receive_pack(uri: web::Path<GitRequest>, mut body: web::Payload, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let content_type = request.get_header("content-type").unwrap_or_default();
     let accept_header = request.get_header("accept").unwrap_or_default();

--- a/src/routes/repository/git/git_upload_pack.rs
+++ b/src/routes/repository/git/git_upload_pack.rs
@@ -15,7 +15,7 @@ use git_repository::protocol::transport::packetline::{PacketLineRef, StreamingPe
 use gitarena_macros::route;
 use sqlx::PgPool;
 
-#[route("/{username}/{repository}.git/git-upload-pack", method="POST")]
+#[route("/{username}/{repository}.git/git-upload-pack", method = "POST", err = "git")]
 pub(crate) async fn git_upload_pack(uri: web::Path<GitRequest>, mut body: web::Payload, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let content_type = request.get_header("content-type").unwrap_or_default();
     let accept_header = request.get_header("accept").unwrap_or_default();

--- a/src/routes/repository/git/git_upload_pack.rs
+++ b/src/routes/repository/git/git_upload_pack.rs
@@ -1,4 +1,4 @@
-use crate::error::GAErrors::GitError;
+use crate::die;
 use crate::git::basic_auth;
 use crate::git::fetch::fetch;
 use crate::git::io::reader::{read_data_lines, read_until_command};
@@ -21,13 +21,13 @@ pub(crate) async fn git_upload_pack(uri: web::Path<GitRequest>, mut body: web::P
     let accept_header = request.get_header("accept").unwrap_or_default();
 
     if content_type != "application/x-git-upload-pack-request" || accept_header != "application/x-git-upload-pack-result" {
-        return Err(GitError(400, None).into());
+        die!(BAD_REQUEST);
     }
 
     let git_protocol = request.get_header("git-protocol").unwrap_or_default();
 
     if git_protocol != "version=2" {
-        return Err(GitError(400, Some("Unsupported Git protocol version".to_owned())).into());
+        die!(BAD_REQUEST, "Unsupported Git protocol version");
     }
 
     let mut transaction = db_pool.begin().await?;
@@ -39,7 +39,7 @@ pub(crate) async fn git_upload_pack(uri: web::Path<GitRequest>, mut body: web::P
 
     let (user_id,) = match user_option {
         Some(user_id) => user_id,
-        None => return Err(GitError(404, None).into())
+        None => die!(NOT_FOUND)
     };
 
     let repo_option: Option<Repository> = sqlx::query_as::<_, Repository>("select * from repositories where owner = $1 and lower(name) = lower($2) limit 1")
@@ -54,7 +54,7 @@ pub(crate) async fn git_upload_pack(uri: web::Path<GitRequest>, mut body: web::P
     };
 
     if !privilege::check_access(&repo, user.as_ref(), &mut transaction).await? {
-        return Err(GitError(404, None).into());
+        die!(NOT_FOUND);
     }
 
     let git2repo = repo.libgit2(&mut transaction).await?;

--- a/src/routes/repository/git/info_refs.rs
+++ b/src/routes/repository/git/info_refs.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use gitarena_macros::route;
 use sqlx::{Executor, PgPool, Pool, Postgres};
 
-#[route("/{username}/{repository}.git/info/refs", method="GET")]
+#[route("/{username}/{repository}.git/info/refs", method = "GET", err = "text")]
 pub(crate) async fn info_refs(uri: web::Path<GitRequest>, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let query_string = request.q_string();
 

--- a/src/routes/repository/git/info_refs.rs
+++ b/src/routes/repository/git/info_refs.rs
@@ -1,4 +1,4 @@
-use crate::error::GAErrors::GitError;
+use crate::die;
 use crate::git::basic_auth;
 use crate::git::capabilities::capabilities;
 use crate::git::ls_refs::ls_refs_all;
@@ -17,7 +17,7 @@ pub(crate) async fn info_refs(uri: web::Path<GitRequest>, request: HttpRequest, 
 
     let service = match query_string.get("service") {
         Some(value) => value.trim(),
-        None => return Err(GitError(400, Some("Dumb clients are not supported".to_owned())).into())
+        None => die!(BAD_REQUEST, "Dumb clients are not supported")
     };
 
     let mut transaction = db_pool.begin().await?;
@@ -29,7 +29,7 @@ pub(crate) async fn info_refs(uri: web::Path<GitRequest>, request: HttpRequest, 
 
     let (user_id,) = match user_option {
         Some(user_id) => user_id,
-        None => return Err(GitError(404, None).into())
+        None => die!(NOT_FOUND)
     };
 
     let repo_option: Option<Repository> = sqlx::query_as::<_, Repository>("select * from repositories where owner = $1 and lower(name) = lower($2) limit 1")
@@ -51,9 +51,7 @@ pub(crate) async fn info_refs(uri: web::Path<GitRequest>, request: HttpRequest, 
 
             Ok(response)
         }
-        _ => {
-            Err(GitError(403, Some("Requested service not found".to_owned())).into())
-        }
+        _ => die!(FORBIDDEN, "Requested service not found")
     }
 }
 
@@ -63,7 +61,7 @@ async fn upload_pack_info_refs<'e, E>(repo_option: Option<Repository>, service: 
     let git_protocol = request.get_header("git-protocol").unwrap_or_default();
 
     if git_protocol != "version=2" {
-        return Err(GitError(400, Some("Unsupported Git protocol version".to_owned())).into());
+        die!(BAD_REQUEST, "Unsupported Git protocol version");
     }
 
     let (_, _) = match basic_auth::validate_repo_access(repo_option, "application/x-git-upload-pack-advertisement", request, executor).await? {
@@ -88,7 +86,7 @@ async fn receive_pack_info_refs(repo_option: Option<Repository>, request: &HttpR
 
     let repo = match repo_option {
         Some(repo) => repo,
-        None => return Err(GitError(404, None).into())
+        None => die!(NOT_FOUND)
     };
 
     let git2repo = repo.libgit2(&mut transaction).await?;

--- a/src/routes/repository/repo_view.rs
+++ b/src/routes/repository/repo_view.rs
@@ -154,7 +154,7 @@ async fn render(tree_option: Option<&str>, repo: Repository, username: &str, web
     render_template!("repo/index.html", context, transaction)
 }
 
-#[route("/{username}/{repository}/tree/{tree:.*}", method="GET")]
+#[route("/{username}/{repository}/tree/{tree:.*}", method = "GET", err = "html")]
 pub(crate) async fn view_repo_tree(uri: web::Path<GitTreeRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 
@@ -164,7 +164,7 @@ pub(crate) async fn view_repo_tree(uri: web::Path<GitTreeRequest>, web_user: Web
     render(Some(uri.tree.as_str()), repo, &uri.username, web_user, transaction).await
 }
 
-#[route("/{username}/{repository}", method="GET")]
+#[route("/{username}/{repository}", method = "GET", err = "html")]
 pub(crate) async fn view_repo(uri: web::Path<GitRequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 

--- a/src/routes/user/avatar.rs
+++ b/src/routes/user/avatar.rs
@@ -21,7 +21,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use sqlx::PgPool;
 
-#[route("/api/avatar/{user_id}", method = "GET")]
+#[route("/api/avatar/{user_id}", method = "GET", err = "text")]
 pub(crate) async fn get_avatar(avatar_request: web::Path<AvatarRequest>, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let (gravatar_enabled, avatars_dir): (bool, String) = from_config!(
         "avatars.gravatar" => bool,
@@ -65,7 +65,7 @@ pub(crate) async fn get_avatar(avatar_request: web::Path<AvatarRequest>, request
     Ok(send_image(path, &request).await.context("Failed to read default avatar file")?)
 }
 
-#[route("/api/avatar", method = "PUT")]
+#[route("/api/avatar", method = "PUT", err = "text")]
 pub(crate) async fn put_avatar(web_user: WebUser, mut payload: Multipart, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if matches!(web_user, WebUser::Anonymous) {
         return Err(HttpError(401, "Not logged in".to_owned()).into());

--- a/src/routes/user/avatar.rs
+++ b/src/routes/user/avatar.rs
@@ -1,8 +1,8 @@
-use crate::error::GAErrors::HttpError;
 use crate::mail::Email;
 use crate::prelude::HttpRequestExtensions;
 use crate::user::WebUser;
 use crate::utils::reqwest_actix_stream::ResponseStream;
+use crate::{die, err};
 
 use std::fs;
 use std::io::Cursor;
@@ -49,7 +49,7 @@ pub(crate) async fn get_avatar(avatar_request: web::Path<AvatarRequest>, request
         } else {
             Email::find_primary_email(avatar_request.user_id, &mut transaction)
                 .await?
-                .ok_or_else(|| HttpError(404, "User not found".to_owned()))?
+                .ok_or_else(|| err!(NOT_FOUND, "User not found"))?
                 .email
         };
 
@@ -68,28 +68,28 @@ pub(crate) async fn get_avatar(avatar_request: web::Path<AvatarRequest>, request
 #[route("/api/avatar", method = "PUT", err = "text")]
 pub(crate) async fn put_avatar(web_user: WebUser, mut payload: Multipart, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if matches!(web_user, WebUser::Anonymous) {
-        return Err(HttpError(401, "Not logged in".to_owned()).into());
+        die!(UNAUTHORIZED, "No logged in");
     }
 
     let user = web_user.into_user()?;
 
     if user.disabled {
-        return Err(HttpError(403, "User is disabled".to_owned()).into());
+        die!(FORBIDDEN, "User is disabled");
     }
 
     let avatars_dir: String = from_config!("avatars.dir" => String);
 
     let mut field = match payload.try_next().await {
         Ok(Some(field)) => field,
-        Ok(None) => return Err(HttpError(400, "No multipart field found".to_owned()).into()),
+        Ok(None) => die!(BAD_REQUEST, "No multipart field found"),
         Err(err) => return Err(err.into())
     };
 
-    let content_disposition = field.content_disposition().ok_or_else(|| HttpError(400, "No content disposition".to_owned()))?;
-    let file_name = content_disposition.get_filename().ok_or_else(|| HttpError(400, "No file name".to_owned()))?;
+    let content_disposition = field.content_disposition().ok_or_else(|| err!(BAD_REQUEST, "No content disposition"))?;
+    let file_name = content_disposition.get_filename().ok_or_else(|| err!(BAD_REQUEST, "No file name"))?;
     let extension = file_name.rsplit_once('.')
         .map(|(_, ext)| ext.to_owned())
-        .ok_or_else(|| HttpError(400, "Invalid file name".to_owned()))?;
+        .ok_or_else(|| err!(BAD_REQUEST, "Invalid file name"))?;
 
     let mut bytes = web::BytesMut::new();
 
@@ -100,7 +100,7 @@ pub(crate) async fn put_avatar(web_user: WebUser, mut payload: Multipart, db_poo
     let frozen_bytes = bytes.freeze();
 
     web::block(move || -> Result<()> {
-        let format = ImageFormat::from_extension(extension).ok_or_else(|| HttpError(400, "Unsupported image format".to_owned()))?;
+        let format = ImageFormat::from_extension(extension).ok_or_else(|| err!(BAD_REQUEST, "Unsupported image format"))?;
 
         let mut cursor = Cursor::new(frozen_bytes.as_ref());
 

--- a/src/routes/user/sso.rs
+++ b/src/routes/user/sso.rs
@@ -20,7 +20,7 @@ use oauth2::TokenResponse;
 use serde::Deserialize;
 use sqlx::PgPool;
 
-#[route("/sso/{service}", method = "GET")]
+#[route("/sso/{service}", method = "GET", err = "html")]
 pub(crate) async fn initiate_sso(sso_request: web::Path<SSORequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if matches!(web_user, WebUser::Authenticated(_)) {
         return Err(HttpError(401, "Already logged in".to_owned()).into());
@@ -36,7 +36,7 @@ pub(crate) async fn initiate_sso(sso_request: web::Path<SSORequest>, web_user: W
     Ok(HttpResponse::TemporaryRedirect().header(LOCATION, url.to_string()).finish())
 }
 
-#[route("/sso/{service}/callback", method = "GET")]
+#[route("/sso/{service}/callback", method = "GET", err = "html")]
 pub(crate) async fn sso_callback(sso_request: web::Path<SSORequest>, id: Identity, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if id.identity().is_some() {
         return Err(HttpError(401, "Already logged in".to_owned()).into());

--- a/src/routes/user/sso.rs
+++ b/src/routes/user/sso.rs
@@ -1,4 +1,3 @@
-use crate::error::GAErrors::HttpError;
 use crate::mail::Email;
 use crate::prelude::HttpRequestExtensions;
 use crate::session::Session;
@@ -6,6 +5,7 @@ use crate::sso::SSO;
 use crate::sso::sso_provider::SSOProvider;
 use crate::sso::sso_provider_type::SSOProviderType;
 use crate::user::{User, WebUser};
+use crate::{die, err};
 
 use std::ops::Deref;
 use std::str::FromStr;
@@ -23,11 +23,11 @@ use sqlx::PgPool;
 #[route("/sso/{service}", method = "GET", err = "html")]
 pub(crate) async fn initiate_sso(sso_request: web::Path<SSORequest>, web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if matches!(web_user, WebUser::Authenticated(_)) {
-        return Err(HttpError(401, "Already logged in".to_owned()).into());
+        die!(UNAUTHORIZED, "Already logged in");
     }
 
     let provider = SSOProviderType::from_str(sso_request.service.as_str())
-        .map_err(|_| HttpError(400, "Unknown service".to_owned()))?;
+        .map_err(|_| err!(BAD_REQUEST, "Unknown service"))?;
     let provider_impl = provider.get_implementation();
 
     // TODO: Save token in cache to check for CSRF
@@ -39,18 +39,18 @@ pub(crate) async fn initiate_sso(sso_request: web::Path<SSORequest>, web_user: W
 #[route("/sso/{service}/callback", method = "GET", err = "html")]
 pub(crate) async fn sso_callback(sso_request: web::Path<SSORequest>, id: Identity, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if id.identity().is_some() {
-        return Err(HttpError(401, "Already logged in".to_owned()).into());
+        die!(UNAUTHORIZED, "Already logged in");
     }
 
     let provider = SSOProviderType::from_str(sso_request.service.as_str())
-        .map_err(|_| HttpError(400, "Unknown service".to_owned()))?;
+        .map_err(|_| err!(BAD_REQUEST, "Unknown service"))?;
     let provider_impl = provider.get_implementation();
 
     let query_string = request.q_string();
     let token_response = SSOProvider::exchange_response(provider_impl.deref(), &query_string, &provider, &db_pool).await?;
 
     if !SSOProvider::validate_scopes(provider_impl.deref(), token_response.scopes()) {
-        return Err(HttpError(409, "Not all required scopes have been granted".to_owned()).into());
+        die!(CONFLICT, "Not all required scopes have been granted");
     }
 
     let access_token = token_response.access_token();
@@ -84,12 +84,12 @@ pub(crate) async fn sso_callback(sso_request: web::Path<SSORequest>, id: Identit
 
     let primary_email = Email::find_primary_email(&user, &mut transaction)
         .await?
-        .ok_or_else(|| HttpError(401, "No primary email".to_owned()))?;
+        .ok_or_else(|| err!(UNAUTHORIZED, "No primary email"))?;
 
     if user.disabled || !primary_email.is_allowed_login() {
         debug!("Received {} sso login request for disabled user {} (id {})", &provider, &user.username, &user.id);
 
-        return Err(HttpError(403, "Account has been disabled. Please contact support.".to_owned()).into());
+        die!(FORBIDDEN, "Account has been disabled. Please contact support.");
     }
 
     // We're now doing something *very* illegal: We're changing state in a GET request

--- a/src/routes/user/user_create.rs
+++ b/src/routes/user/user_create.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use tera::Context;
 
-#[route("/register", method = "GET")]
+#[route("/register", method = "GET", err = "html")]
 pub(crate) async fn get_register(web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let mut transaction = db_pool.begin().await?;
 
@@ -37,7 +37,7 @@ pub(crate) async fn get_register(web_user: WebUser, db_pool: web::Data<PgPool>) 
     render_template!("user/register.html", context, transaction)
 }
 
-#[route("/api/user", method = "POST")]
+#[route("/api/user", method = "POST", err = "htmx+html")]
 pub(crate) async fn post_register(body: web::Json<RegisterJsonRequest>, id: Identity, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if id.identity().is_some() {
         // Maybe just redirect to home page?

--- a/src/routes/user/user_create.rs
+++ b/src/routes/user/user_create.rs
@@ -1,11 +1,10 @@
 use crate::config::{get_optional_setting, get_setting};
-use crate::error::GAErrors::HttpError;
 use crate::prelude::*;
 use crate::session::Session;
 use crate::user::{User, WebUser};
 use crate::utils::identifiers::{is_username_taken, validate_username};
 use crate::verification::send_verification_mail;
-use crate::{captcha, crypto, render_template};
+use crate::{captcha, crypto, die, render_template};
 
 use actix_identity::Identity;
 use actix_web::{HttpRequest, HttpResponse, Responder, web};
@@ -21,13 +20,13 @@ pub(crate) async fn get_register(web_user: WebUser, db_pool: web::Data<PgPool>) 
     let mut transaction = db_pool.begin().await?;
 
     if matches!(web_user, WebUser::Authenticated(_)) {
-        return Err(HttpError(401, "Already logged in".to_owned()).into());
+        die!(UNAUTHORIZED, "Already logged in");
     }
 
     let mut context = Context::new();
 
     if !get_setting::<bool, _>("allow_registrations", &mut transaction).await? {
-        return Err(HttpError(403, "User registrations are disabled".to_owned()).into());
+        die!(FORBIDDEN, "User registrations are disabled");
     }
 
     if let Some(site_key) = get_optional_setting::<String, _>("hcaptcha.site_key", &mut transaction).await? {
@@ -41,13 +40,13 @@ pub(crate) async fn get_register(web_user: WebUser, db_pool: web::Data<PgPool>) 
 pub(crate) async fn post_register(body: web::Json<RegisterJsonRequest>, id: Identity, request: HttpRequest, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if id.identity().is_some() {
         // Maybe just redirect to home page?
-        return Err(HttpError(401, "Already logged in".to_owned()).into());
+        die!(UNAUTHORIZED, "Already logged in");
     }
 
     let mut transaction = db_pool.begin().await?;
 
     if !get_setting::<bool, _>("allow_registrations", &mut transaction).await? {
-        return Err(HttpError(403, "User registrations are disabled".to_owned()).into());
+        die!(FORBIDDEN, "User registrations are disabled");
     }
 
     let username = &body.username;
@@ -55,7 +54,7 @@ pub(crate) async fn post_register(body: web::Json<RegisterJsonRequest>, id: Iden
     validate_username(username.as_str())?;
 
     if is_username_taken(username.as_str(), &mut transaction).await? {
-        return Err(HttpError(409, "Username already in use".to_owned()).into());
+        die!(CONFLICT, "Username already in use");
     }
 
     let email = &body.email;
@@ -63,7 +62,7 @@ pub(crate) async fn post_register(body: web::Json<RegisterJsonRequest>, id: Iden
     // This is not according to the spec of the IETF but trying to implement that is honestly out-of-bounds for this project
     // Thus a best effort naive implementation. Checks for the presence of "@" and a "." in the domain name (after the last @)
     if !email.contains('@') || !email.rsplit_once("@").map(|(_, x)| x).unwrap_or_default().contains('.') {
-        return Err(HttpError(400, "Invalid email address".to_owned()).into());
+        die!(BAD_REQUEST, "Invalid email address");
     }
 
     let (email_exists,): (bool,) = sqlx::query_as("select exists(select 1 from emails where lower(email) = lower($1) limit 1)")
@@ -72,7 +71,7 @@ pub(crate) async fn post_register(body: web::Json<RegisterJsonRequest>, id: Iden
         .await?;
 
     if email_exists {
-        return Err(HttpError(409, "Email already in use".to_owned()).into());
+        die!(CONFLICT, "Email already in use");
     }
 
     let raw_password = &body.password;
@@ -80,7 +79,7 @@ pub(crate) async fn post_register(body: web::Json<RegisterJsonRequest>, id: Iden
     // We don't implement any strict password rules according to NIST 2017 Guidelines
     // TODO: Allow configuration of password rules
     if raw_password.len() < 8 {
-        return Err(HttpError(400, "Password must be at least 8 characters".to_owned()).into());
+        die!(BAD_REQUEST, "Password must be at least 8 characters");
     }
 
     let password = crypto::hash_password(raw_password)?;
@@ -90,10 +89,10 @@ pub(crate) async fn post_register(body: web::Json<RegisterJsonRequest>, id: Iden
             let captcha_success = captcha::verify_captcha(h_captcha_response, &mut transaction).await?;
 
             if !captcha_success {
-                return Err(HttpError(422, "Captcha verification failed".to_owned()).into());
+                die!(UNPROCESSABLE_ENTITY, "Captcha verification failed");
             }
         } else {
-            return Err(HttpError(400, "HCaptcha response was not provided".to_owned()).into());
+            die!(BAD_REQUEST, "HCaptcha response was not provided");
         }
     }
 

--- a/src/routes/user/user_login.rs
+++ b/src/routes/user/user_login.rs
@@ -18,7 +18,7 @@ use tera::Context;
 use tracing_unwrap::OptionExt;
 use log::debug;
 
-#[route("/login", method = "GET")]
+#[route("/login", method = "GET", err = "html")]
 pub(crate) async fn get_login(web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if matches!(web_user, WebUser::Authenticated(_)) {
         return Err(HttpError(401, "Already logged in".to_owned()).into());
@@ -41,7 +41,7 @@ pub(crate) async fn get_login(web_user: WebUser, db_pool: web::Data<PgPool>) -> 
     render_template!("user/login.html", context)
 }
 
-#[route("/login", method = "POST")]
+#[route("/login", method = "POST", err = "html")]
 pub(crate) async fn post_login(body: web::Form<LoginRequest>, request: HttpRequest, id: Identity, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let redirect = body.redirect.as_deref().unwrap_or("/");
 

--- a/src/routes/user/user_logout.rs
+++ b/src/routes/user/user_logout.rs
@@ -10,7 +10,7 @@ use gitarena_macros::route;
 use log::debug;
 use sqlx::PgPool;
 
-#[route("/logout", method = "POST")]
+#[route("/logout", method = "POST", err = "htmx+html")]
 pub(crate) async fn logout(request: HttpRequest, id: Identity, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if id.identity().is_none() {
         // Maybe just redirect to home page?

--- a/src/routes/user/user_logout.rs
+++ b/src/routes/user/user_logout.rs
@@ -1,5 +1,5 @@
-use crate::error::GAErrors::HttpError;
-use crate::prelude::*;
+use crate::die;
+use crate::prelude::HttpRequestExtensions;
 use crate::session::Session;
 
 use actix_identity::Identity;
@@ -14,7 +14,7 @@ use sqlx::PgPool;
 pub(crate) async fn logout(request: HttpRequest, id: Identity, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     if id.identity().is_none() {
         // Maybe just redirect to home page?
-        return Err(HttpError(401, "Already logged out".to_owned()).into());
+        die!(UNAUTHORIZED, "Already logged out");
     }
 
     let mut transaction = db_pool.begin().await?;

--- a/src/routes/user/user_verify.rs
+++ b/src/routes/user/user_verify.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use sqlx::PgPool;
 use tracing_unwrap::OptionExt;
 
-#[route("/api/verify/{token}", method="GET")]
+#[route("/api/verify/{token}", method = "GET", err = "html")]
 pub(crate) async fn verify(verify_request: web::Path<VerifyRequest>, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
     let token = &verify_request.token;
 

--- a/src/routes/user/user_verify.rs
+++ b/src/routes/user/user_verify.rs
@@ -1,4 +1,4 @@
-use crate::error::GAErrors::HttpError;
+use crate::die;
 
 use actix_web::{Responder, web};
 use anyhow::Result;
@@ -14,7 +14,7 @@ pub(crate) async fn verify(verify_request: web::Path<VerifyRequest>, db_pool: we
     let token = &verify_request.token;
 
     if token.len() != 32 || !token.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(HttpError(400, "Token is illegal".to_owned()).into());
+        die!(BAD_REQUEST, "Token is illegal");
     }
 
     let mut transaction = db_pool.begin().await?;
@@ -25,7 +25,7 @@ pub(crate) async fn verify(verify_request: web::Path<VerifyRequest>, db_pool: we
         .await?;
 
     if option.is_none() {
-        return Err(HttpError(403, "Token does not exist or has expired".to_owned()).into());
+        die!(FORBIDDEN, "Token does not exist or has expired");
     }
 
     let (row_id, user_id) = option.unwrap_or_log();
@@ -44,6 +44,7 @@ pub(crate) async fn verify(verify_request: web::Path<VerifyRequest>, db_pool: we
 
     info!("User id {} verified their e-mail", user_id);
 
+    // TODO: Show html success page instead of json
     Ok(web::Json(json!({
         "success": true
     })))

--- a/src/utils/identifiers.rs
+++ b/src/utils/identifiers.rs
@@ -1,4 +1,4 @@
-use crate::error::GAErrors::HttpError;
+use crate::die;
 
 use anyhow::Result;
 use sqlx::{Executor, Postgres};
@@ -66,15 +66,15 @@ pub(crate) fn is_reserved_username(input: &str) -> bool {
 /// [0]: crate::error::GAErrors::HttpError
 pub(crate) fn validate_username(input: &str) -> Result<()> {
     if input.len() < 3 || input.len() > 32 || !input.chars().all(|c| is_valid(&c)) {
-        return Err(HttpError(400, "Username must be between 3 and 32 characters long and may only contain a-z, 0-9, _ or -".to_owned()).into());
+        die!(BAD_REQUEST, "Username must be between 3 and 32 characters long and may only contain a-z, 0-9, _ or -");
     }
 
     if is_reserved_username(input) {
-        return Err(HttpError(400, "Username is a reserved identifier".to_owned()).into());
+        die!(CONFLICT, "Username is a reserved identifier");
     }
 
     if !is_fs_legal(input) {
-        return Err(HttpError(400, "Username is illegal".to_owned()).into());
+        die!(BAD_REQUEST, "Username is illegal");
     }
 
     Ok(())


### PR DESCRIPTION
GitArena's error handling is currently in a very messy state. This pull request aims to fix this.

- New early exit macro `die!`. This is meant to replace the old `return Err(GAError::Type.into());` pattern that can be seen in almost every route.
- Move error handling representation (html, json, git, plain text) specification from specific `Error`s to the route as a whole
- Remove GitArena internal specific error enum. GitArena is a binary application and thus we don't really need to care which error type we pass around. Most calls will be replaced with `anyhow!`.
- Allow propagated errors (passed along using `?`) to have a custom status code instead of always resulting in an `500 Internal server error`. Maybe there should be a helper trait for this.

This propsal would transform current routes to look something like this:

```rust
#[route("/login", method = "GET", err = "html")]
pub(crate) async fn get_login(web_user: WebUser, db_pool: web::Data<PgPool>) -> Result<impl Responder> {
    if matches!(web_user, WebUser::Authenticated(_)) {
        die!(UNAUTHORIZED, "Already logged in");
    }

    ...
}
```

In case a error in this route occurs (either throught a propagated error using `?` or a specificly crafted one using the `die!` macro, the error will be displayed as html (`err = "html"`) to the end user. The error message will be shown under either of these two specific circumenstances:

1. The error has been caused by the `die!` macro *and* has a message supplied with it as second argument
2. The propagated error was `.map_err` to a `GitArenaError` which has `display` set to `true`. Maybe we should also make a trait with an extension method `.display()` which makes this more convient to use.

If none of these two are met, the generic message will be displayed corresponding to the error's status code. For a 500 error that would be `Internal server error` or for a 401 `Unauthorized`